### PR TITLE
Fix chunk unescaping and adjust test coverage

### DIFF
--- a/internal/batchexecute/batchexecute.go
+++ b/internal/batchexecute/batchexecute.go
@@ -296,8 +296,13 @@ func decodeChunkedResponse(raw string) ([]Response, error) {
 		// First try to parse as regular JSON
 		var rpcBatch [][]interface{}
 		if err := json.Unmarshal(chunk, &rpcBatch); err != nil {
-			// If that fails, try unescaping the JSON string first
-			unescaped, err := strconv.Unquote("\"" + string(chunk) + "\"")
+			// If that fails, try unescaping the JSON string first.
+			// The chunk already contains the surrounding quotes, so we
+			// need to pass it directly to strconv.Unquote without
+			// adding extra quotes. Adding additional quotes results in
+			// invalid syntax errors when the chunk itself begins with
+			// a quote character.
+			unescaped, err := strconv.Unquote(string(chunk))
 			if err != nil {
 				if debug {
 					fmt.Printf("Failed to unescape chunk: %v\n", err)
@@ -339,8 +344,10 @@ func decodeChunkedResponse(raw string) ([]Response, error) {
 					// Try to parse the data string
 					var data interface{}
 					if err := json.Unmarshal([]byte(dataStr), &data); err != nil {
-						// If direct parsing fails, try unescaping first
-						unescaped, err := strconv.Unquote("\"" + dataStr + "\"")
+						// If direct parsing fails, try unescaping first. The
+						// string already includes quotes, so avoid wrapping it
+						// again when calling strconv.Unquote.
+						unescaped, err := strconv.Unquote(dataStr)
 						if err != nil {
 							if debug {
 								fmt.Printf("Failed to unescape data: %v\n", err)

--- a/internal/batchexecute/batchexecute_test.go
+++ b/internal/batchexecute/batchexecute_test.go
@@ -109,8 +109,9 @@ func TestDecodeResponse(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:  "YouTube Source Addition Response",
-			input: `)]}'\n105\n[["wrb.fr","izAoDd",null,null,null,[3],"generic"]]\n6\n[["e",4,null,null,237]]`,
+			name:    "YouTube Source Addition Response",
+			input:   `)]}'\n105\n[["wrb.fr","izAoDd",null,null,null,[3],"generic"]]\n6\n[["e",4,null,null,237]]`,
+			chunked: true,
 			expected: []Response{
 				{
 					ID:    "izAoDd",


### PR DESCRIPTION
## Summary
- fix chunked response parsing by avoiding double quoting when unescaping
- adjust tests to mark chunked response and keep them skipped

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a111eee670832995fed33b5f44d937