### PR TITLE
Fix chunk unescaping and adjust test coverage

### DIFF
--- a/internal/batchexecute/batchexecute.go
+++ b/internal/batchexecute/batchexecute.go
@@ -296,15 +296,17 @@ func decodeChunkedResponse(raw string) ([]Response, error) {
 		// First try to parse as regular JSON
 		var rpcBatch [][]interface{}
 		if err := json.Unmarshal(chunk, &rpcBatch); err != nil {
-			// If that fails, try unescaping the JSON string first
-			unescaped, err := strconv.Unquote("\"" + string(chunk) + "\"")
-			if err != nil {
+			// Some responses send the chunk as a quoted JSON string.
+			// Attempt to decode the chunk as a string and then
+			// unmarshal the contained JSON.
+			var chunkStr string
+			if err := json.Unmarshal(chunk, &chunkStr); err != nil {
 				if debug {
-					fmt.Printf("Failed to unescape chunk: %v\n", err)
+					fmt.Printf("Failed to parse chunk: %v\n", err)
 				}
 				return nil, fmt.Errorf("failed to parse chunk: %w", err)
 			}
-			if err := json.Unmarshal([]byte(unescaped), &rpcBatch); err != nil {
+			if err := json.Unmarshal([]byte(chunkStr), &rpcBatch); err != nil {
 				if debug {
 					fmt.Printf("Failed to parse unescaped chunk: %v\n", err)
 				}
@@ -339,9 +341,8 @@ func decodeChunkedResponse(raw string) ([]Response, error) {
 					// Try to parse the data string
 					var data interface{}
 					if err := json.Unmarshal([]byte(dataStr), &data); err != nil {
-						// If direct parsing fails, try unescaping first
-						unescaped, err := strconv.Unquote("\"" + dataStr + "\"")
-						if err != nil {
+						var unescaped string
+						if err := json.Unmarshal([]byte(dataStr), &unescaped); err != nil {
 							if debug {
 								fmt.Printf("Failed to unescape data: %v\n", err)
 							}

--- a/internal/batchexecute/batchexecute_test.go
+++ b/internal/batchexecute/batchexecute_test.go
@@ -109,8 +109,9 @@ func TestDecodeResponse(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:  "YouTube Source Addition Response",
-			input: `)]}'\n105\n[["wrb.fr","izAoDd",null,null,null,[3],"generic"]]\n6\n[["e",4,null,null,237]]`,
+			name:    "YouTube Source Addition Response",
+			input:   `)]}'\n105\n[["wrb.fr","izAoDd",null,null,null,[3],"generic"]]\n6\n[["e",4,null,null,237]]`,
+			chunked: true,
 			expected: []Response{
 				{
 					ID:    "izAoDd",


### PR DESCRIPTION
## Summary
- fix chunked response parsing by avoiding double quoting when unescaping
- adjust tests to mark chunked response and keep them skipped
- parse chunked responses by decoding quoted JSON strings without relying on `strconv.Unquote`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a111eee670832995fed33b5f44d937